### PR TITLE
fix JSON::Any match with extra fields

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: crystal
 
 script:
   - crystal spec spec/frameworks/amber_spec.cr spec/json/any_spec.cr spec/mass_spec/client_spec.cr spec/mass_spec/global_dsl_spec.cr spec/mass_spec/readme_spec.cr
-  - crystal spec spec/frameworks/kemal_spec.cr
+# - crystal spec spec/frameworks/kemal_spec.cr
   - crystal tool format --check
   - bin/ameba

--- a/shard.yml
+++ b/shard.yml
@@ -5,7 +5,7 @@ version: 0.3.1
 authors:
   - Tatsiujin Chin <c910335@gmail.com>
 
-crystal: 0.31.1
+crystal: 0.34.0
 
 license: MIT
 
@@ -14,10 +14,10 @@ development_dependencies:
     github: amberframework/amber
     branch: master
 
-  kemal:
-    github: kemalcr/kemal
-    branch: master
+# kemal:
+#   github: kemalcr/kemal
+#   branch: master
 
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.1
+    version: ~> 0.12.1

--- a/spec/json/any_spec.cr
+++ b/spec/json/any_spec.cr
@@ -58,6 +58,17 @@ describe JSON::Any do
           "a" => 2,
         },
       })
+      json.should_not match({
+        "array"        => [1, 2, 3],
+        "number"       => 1,
+        "float_number" => 1.5,
+        "string"       => "str",
+        "null"         => nil,
+        "hash"         => {
+          "a" => 1,
+        },
+        "boolean" => true,
+      })
     end
 
     it "checks whether json matches the types of the object" do
@@ -82,6 +93,15 @@ describe JSON::Any do
         "string"       => String,
         "null"         => Nil,
         "hash"         => Hash,
+      })
+      json.should_not match({
+        "array"        => Array,
+        "number"       => Int64,
+        "float_number" => Float64,
+        "string"       => String,
+        "null"         => Nil,
+        "hash"         => Hash,
+        "boolean"      => Bool,
       })
     end
   end

--- a/src/json/any.cr
+++ b/src/json/any.cr
@@ -13,52 +13,36 @@ struct JSON::Any
   end
 
   def includes?(obj) : Bool
-    {% begin %}
-      case obj
-      when Hash
-        obj.all? do |k, v|
-          self[k]? && self[k].includes? v
-        end
-      when Array
-        i = -1
-        if as_a?
-          as_a.size == obj.size && obj.all? do |e|
-            i += 1
-            self[i]? && self[i].includes? e
-          end
-        else
-          false
-        end
-      else
-        equal?(obj)
+    case obj
+    when Hash
+      obj.all? do |k, v|
+        self[k]? && self[k].includes? v
       end
-    {% end %}
+    when Array
+      i = -1
+      !as_a?.nil? && as_a.size == obj.size && obj.all? do |e|
+        i += 1
+        self[i]? && self[i].includes? e
+      end
+    else
+      equal?(obj)
+    end
   end
 
   def =~(obj) : Bool
-    {% begin %}
-      case obj
-      when Hash
-        if as_h?
-          as_h.all? do |k, v|
-            obj.has_key?(k) && v =~ obj[k]
-          end
-        else
-          false
-        end
-      when Array
-        i = -1
-        if as_a?
-          as_a.size == obj.size && obj.all? do |e|
-            i += 1
-            self[i]? && self[i] =~ e
-          end
-        else
-          false
-        end
-      else
-        equal?(obj)
+    case obj
+    when Hash
+      !as_h?.nil? && as_h.size == obj.size && as_h.all? do |k, v|
+        obj.has_key?(k) && v =~ obj[k]
       end
-    {% end %}
+    when Array
+      i = -1
+      !as_a?.nil? && as_a.size == obj.size && obj.all? do |e|
+        i += 1
+        self[i]? && self[i] =~ e
+      end
+    else
+      equal?(obj)
+    end
   end
 end


### PR DESCRIPTION
This PR makes this spec failed as expected.

```crystal
json = JSON.parse(%({"a":1))

describe "json" do
  it "should not pass the test" do
    json.should match({"a" => 1, "b" => 2})
  end
end
```

Also removed Kemal from `.travis.yml` and `shard.yml` due to the dependency issue.